### PR TITLE
クエリ文字列を指定して検索するAPIを実装

### DIFF
--- a/src/main/java/com/example/assessment/AssessmentController.java
+++ b/src/main/java/com/example/assessment/AssessmentController.java
@@ -1,6 +1,7 @@
 package com.example.assessment;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -16,7 +17,7 @@ public class AssessmentController {
 
 
     @GetMapping("/assessments")
-    public List<Assessment> findAll() {
-        return assessmentMapper.findAll();
+    public List<Assessment> findByAssessments(@RequestParam String startsWith) {
+        return assessmentMapper.findByNameStartingWith(startsWith);
     }
 }

--- a/src/main/java/com/example/assessment/AssessmentMapper.java
+++ b/src/main/java/com/example/assessment/AssessmentMapper.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 @Mapper
 public interface AssessmentMapper {
-    @Select("SELECT * FROM assessments")
-    List<Assessment> findAll();
+    @Select("SELECT * FROM assessments WHERE name LIKE CONCAT(#{prefix}, '%' )")
+    List<Assessment> findByNameStartingWith(String prefix);
 }


### PR DESCRIPTION
# 概要

クエリ文字列を指定して検索するAPIを実装しました。
- フィットネストレーナーが用いるアセスメントシートをDBで作成し、READ処置を実装しました。

# 動作確認

下記確認済みです。
- ステータスコードが200であること
- json形式であること
- クエリ文字列を「上」と指定すると、「上」で始まるnameのレコードが表示されていること

![スクリーンショット (43)](https://github.com/affy03/assignment8/assets/159910151/90d31ed8-98b3-40dd-86df-a130673feb42)




